### PR TITLE
Fix vagrant url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,7 +17,7 @@ class vagrant(
 
   package { "Vagrant_${version}":
     ensure   => installed,
-    source   => "https://dl.bintray.com/mitchellh/vagrant/vagrant_${version}.dmg",
+    source   => "https://releases.hashicorp.com/vagrant/${version}/vagrant_${version}.dmg",
     provider => 'pkgdmg'
   }
 

--- a/spec/classes/vagrant_spec.rb
+++ b/spec/classes/vagrant_spec.rb
@@ -14,14 +14,14 @@ describe 'vagrant' do
     let (:params) {{:version => '1.5.0'}}
 
     it { should contain_package('Vagrant_1.5.0')}
-    it { should contain_package('Vagrant_1.5.0').with_source('https://dl.bintray.com/mitchellh/vagrant/vagrant_1.5.0.dmg')}
+    it { should contain_package('Vagrant_1.5.0').with_source('https://releases.hashicorp.com/vagrant/1.5.0/vagrant_1.5.0.dmg')}
   end
 
   describe 'when installing bash completion' do
     let (:params) {{:completion => true}}
 
     it { should contain_package('Vagrant_1.7.4')}
-    it { should contain_package('Vagrant_1.7.4').with_source('https://dl.bintray.com/mitchellh/vagrant/vagrant_1.7.4.dmg')}
+    it { should contain_package('Vagrant_1.7.4').with_source('https://releases.hashicorp.com/vagrant/1.7.4/vagrant_1.7.4.dmg')}
     it { should contain_package('vagrant-completion').with_provider('homebrew')}
   end
 


### PR DESCRIPTION
Hashicorp moved their packages to https://releases.hashicorp.com no more bintray on Mitchel's account.

